### PR TITLE
Create codecov.yml

### DIFF
--- a/.github/codecov.yml
+++ b/.github/codecov.yml
@@ -1,0 +1,25 @@
+codecov:
+  require_ci_to_pass: yes
+
+coverage:
+  precision: 2
+  round: down
+  range: "50...100"
+  status:
+    project:
+      default:
+        threshold: 5%
+        target: 0%
+
+parsers:
+  gcov:
+    branch_detection:
+      conditional: yes
+      loop: yes
+      method: no
+      macro: no
+
+comment:
+  layout: "reach,diff,flags,files,footer"
+  behavior: default
+  require_changes: no


### PR DESCRIPTION
Add codecov.yml file to remove the strict checks on current commits/PRs.
This config removes the minimum coverage target and sets a threshold of maximum 5% drop in total coverage.