### PR TITLE
Refactor EtlStats

### DIFF
--- a/src/omop_etl_wrapper/model/etl_stats.py
+++ b/src/omop_etl_wrapper/model/etl_stats.py
@@ -142,6 +142,11 @@ class EtlStats:
         transformations_df = transformations_df.append([t.to_dict() for t in self.transformations])
         return transformations_df[EtlTransformation.df_column_order]
 
+    def reset(self) -> None:
+        """Remove all stored Etl objects from this instance."""
+        self.transformations = []
+        self.sources = []
+
     @staticmethod
     def get_total_duration(etl_objects: Union[List[EtlTransformation], List[EtlSource]]) -> datetime.timedelta:
         durations = (obj.duration for obj in etl_objects if obj.start and obj.end)

--- a/src/omop_etl_wrapper/model/etl_stats.py
+++ b/src/omop_etl_wrapper/model/etl_stats.py
@@ -207,3 +207,6 @@ class EtlStats:
         output_dir.mkdir(exist_ok=True)
         self.sources_df.to_csv(output_dir / f'{time_str}_sources.tsv', sep='\t', index=False)
         self.transformations_df.to_csv(output_dir / f'{time_str}_transformations.tsv', sep='\t', index=False)
+
+
+etl_stats = EtlStats()

--- a/src/omop_etl_wrapper/model/orm_wrapper.py
+++ b/src/omop_etl_wrapper/model/orm_wrapper.py
@@ -23,7 +23,7 @@ from typing import Callable, List
 
 from sqlalchemy.orm.session import Session
 
-from .etl_stats import EtlTransformation, EtlStats
+from .etl_stats import EtlTransformation, etl_stats
 from ..database.database import Database
 
 logger = logging.getLogger(__name__)
@@ -36,7 +36,6 @@ class OrmWrapper(ABC):
     """
     def __init__(self, database: Database):
         self.db = database
-        self.etl_stats = EtlStats()
 
     @property
     @abstractmethod
@@ -78,7 +77,7 @@ class OrmWrapper(ABC):
 
         transformation_metadata.end = datetime.now()
         logger.info(f'{statement.__name__} completed with success status: {transformation_metadata.query_success}')
-        self.etl_stats.add_transformation(transformation_metadata)
+        etl_stats.add_transformation(transformation_metadata)
 
     @staticmethod
     def _collect_query_statistics_bulk_mode(session: Session,

--- a/src/omop_etl_wrapper/model/raw_sql_wrapper.py
+++ b/src/omop_etl_wrapper/model/raw_sql_wrapper.py
@@ -8,7 +8,7 @@ from typing import Dict
 from sqlalchemy import text
 from sqlalchemy.engine.result import ResultProxy
 
-from .etl_stats import EtlTransformation, EtlStats
+from .etl_stats import EtlTransformation, etl_stats
 from ..config.models import MainConfig
 from ..database.database import Database
 from ..util.helper import replace_substrings
@@ -22,7 +22,6 @@ class RawSqlWrapper:
     """
     def __init__(self, database: Database, config: MainConfig):
         self.db = database
-        self.etl_stats = EtlStats()
         self.sql_parameters = self._get_sql_parameters(config)
 
     @staticmethod
@@ -61,7 +60,7 @@ class RawSqlWrapper:
                 transformation_metadata.query_success = False
 
         transformation_metadata.end = datetime.now()
-        self.etl_stats.add_transformation(transformation_metadata)
+        etl_stats.add_transformation(transformation_metadata)
 
     @staticmethod
     def apply_sql_parameters(parameterized_query: str, sql_parameters: Dict[str, str]):

--- a/src/omop_etl_wrapper/model/source_data/source_data.py
+++ b/src/omop_etl_wrapper/model/source_data/source_data.py
@@ -7,7 +7,7 @@ from typing import Dict
 
 from .source_file import SourceFile
 from ...config.models import SourceConfig
-from ...model.etl_stats import EtlSource, EtlStats
+from ...model.etl_stats import EtlSource, etl_stats
 from ...util import io
 
 logger = logging.getLogger(__name__)
@@ -15,9 +15,8 @@ logger = logging.getLogger(__name__)
 
 class SourceData:
     """Handle for all interactions related to source data files."""
-    def __init__(self, config: Dict, etl_stats: EtlStats):
+    def __init__(self, config: Dict):
         self.source_config: SourceConfig = SourceConfig(**config)
-        self._etl_stats = etl_stats
         self._source_dir = self.source_config.source_data_folder
         self._file_defaults: Dict = self.source_config.file_defaults
         self._source_files: Dict[str, SourceFile] = self._collect_source_files()
@@ -54,4 +53,4 @@ class SourceData:
             row_count = source_file.get_line_count()
             end_time = datetime.now()
             etl_source = EtlSource(start_time, end_time, file_name, row_count)
-            self._etl_stats.add_source(etl_source)
+            etl_stats.add_source(etl_source)

--- a/src/omop_etl_wrapper/model/stcm/stcm_loader.py
+++ b/src/omop_etl_wrapper/model/stcm/stcm_loader.py
@@ -13,7 +13,7 @@ from ..._paths import STCM_DIR, STCM_VERSION_FILE
 from ...cdm._schema_placeholders import VOCAB_SCHEMA
 from ...cdm.vocabularies import BaseSourceToConceptMapVersion
 from ...database import Database
-from ...model.etl_stats import EtlTransformation, EtlStats
+from ...model.etl_stats import EtlTransformation, etl_stats
 from ...util.io import is_hidden
 
 logger = logging.getLogger(__name__)
@@ -22,10 +22,9 @@ _STCM_VERSION_TABLE_NAME = BaseSourceToConceptMapVersion.__tablename__
 
 
 class StcmLoader:
-    def __init__(self, db: Database, cdm, etl_stats: EtlStats):
+    def __init__(self, db: Database, cdm):
         self._db = db
         self._cdm = cdm
-        self._etl_stats = etl_stats
         # STCM versions previously loaded into the db
         self._loaded_stcm_versions: Dict[str, str] = {}
         # Newly provided STCM versions from stcm_versions.tsv
@@ -167,7 +166,7 @@ class StcmLoader:
                 session.add(self._cdm.SourceToConceptMap(**row))
 
             transformation_metadata.end = datetime.now()
-            self._etl_stats.add_transformation(transformation_metadata)
+            etl_stats.add_transformation(transformation_metadata)
 
             if unrecognized_vocabs:
                 logger.warning(f'Skipped records with source_vocabulary_id values that '

--- a/src/omop_etl_wrapper/model/vocab_manager.py
+++ b/src/omop_etl_wrapper/model/vocab_manager.py
@@ -1,7 +1,6 @@
 import logging
 
 from .custom_vocab import CustomVocabLoader
-from .etl_stats import EtlStats
 from .stcm import StcmLoader
 from ..config.models import MainConfig
 from ..database import Database
@@ -10,9 +9,9 @@ logger = logging.getLogger(__name__)
 
 
 class VocabManager:
-    def __init__(self, db: Database, cdm, config: MainConfig, etl_stats: EtlStats):
+    def __init__(self, db: Database, cdm, config: MainConfig):
         self._custom_vocab_loader = CustomVocabLoader(db, cdm)
-        self._stcm_loader = StcmLoader(db, cdm, etl_stats)
+        self._stcm_loader = StcmLoader(db, cdm)
 
         self._load_custom_vocabs = not config.run_options.skip_custom_vocabulary_loading
         self._load_stcm = not config.run_options.skip_source_to_concept_map_loading

--- a/src/omop_etl_wrapper/wrapper.py
+++ b/src/omop_etl_wrapper/wrapper.py
@@ -129,3 +129,8 @@ class Wrapper(OrmWrapper, RawSqlWrapper):
                 if not conn.dialect.has_schema(conn, schema_name):
                     logger.info(f'Creating schema: {schema_name}')
                     self.db.engine.execute(CreateSchema(schema_name))
+
+    def summarize(self) -> None:
+        etl_stats.log_summary()
+        if self._config.run_options.write_reports:
+            etl_stats.write_summary_files()

--- a/src/omop_etl_wrapper/wrapper.py
+++ b/src/omop_etl_wrapper/wrapper.py
@@ -55,8 +55,8 @@ class Wrapper(OrmWrapper, RawSqlWrapper):
     def _set_source_data(self):
         source_data_path = self._config.source_data_folder
         if source_data_path is None:
-            logger.info(f'No source_data_folder provided in config file, '
-                        f'assuming no source data files are present')
+            logger.info('No source_data_folder provided in config file, '
+                        'assuming no source data files are present')
             return None
         if not SOURCE_DATA_CONFIG_PATH.exists():
             logger.info(f'No source data config file found at {SOURCE_DATA_CONFIG_PATH}, '

--- a/src/omop_etl_wrapper/wrapper.py
+++ b/src/omop_etl_wrapper/wrapper.py
@@ -131,6 +131,16 @@ class Wrapper(OrmWrapper, RawSqlWrapper):
                     self.db.engine.execute(CreateSchema(schema_name))
 
     def summarize(self) -> None:
+        """
+        Summarize the results of the transformations.
+
+        Logs an overview of all transformations and data sources that
+        were used for the current run. If **write_reports** is set to
+        True in the main config file, two overview files will be written
+        to the logs folder with more detailed information.
+
+        :return: None
+        """
         etl_stats.log_summary()
         if self._config.run_options.write_reports:
             etl_stats.write_summary_files()

--- a/src/omop_etl_wrapper/wrapper.py
+++ b/src/omop_etl_wrapper/wrapper.py
@@ -11,12 +11,12 @@ from .cdm import vocabularies as cdm
 from .cdm._schema_placeholders import VOCAB_SCHEMA
 from .config.models import MainConfig
 from .database import Database
-from .model.etl_stats import EtlStats
+from .model.etl_stats import etl_stats
+from .model.mapping import CodeMapper
 from .model.orm_wrapper import OrmWrapper
 from .model.raw_sql_wrapper import RawSqlWrapper
 from .model.source_data import SourceData
 from .model.vocab_manager import VocabManager
-from .model.mapping import CodeMapper
 from .util.io import read_yaml_file
 
 logger = logging.getLogger(__name__)
@@ -38,25 +38,22 @@ class Wrapper(OrmWrapper, RawSqlWrapper):
         :param cdm_: Module containing the SQLAlchemy declarative Base
             and the CDM tables.
         """
+        etl_stats.reset()
+        self._config = config
         self.db = Database.from_config(config, cdm_.Base)
 
         if not self.db.can_connect(str(self.db.engine.url)):
             sys.exit()
 
-        self.write_reports = config.run_options.write_reports
-
         super().__init__(database=self.db)
         super(OrmWrapper, self).__init__(database=self.db, config=config)
 
-        self.etl_stats = EtlStats()
-
-        source_data_path = config.source_data_folder
-        self.source_data: Optional[SourceData] = self._set_source_data(source_data_path)
-        
-        self.vocab_manager = VocabManager(self.db, cdm_, config, self.etl_stats)
+        self.source_data: Optional[SourceData] = self._set_source_data()
+        self.vocab_manager = VocabManager(self.db, cdm_, config)
         self.code_mapper = CodeMapper(self.db, cdm_)
 
-    def _set_source_data(self, source_data_path: Optional[Path]):
+    def _set_source_data(self):
+        source_data_path = self._config.source_data_folder
         if source_data_path is None:
             logger.info(f'No source_data_folder provided in config file, '
                         f'assuming no source data files are present')
@@ -67,7 +64,7 @@ class Wrapper(OrmWrapper, RawSqlWrapper):
             return None
         source_config = read_yaml_file(SOURCE_DATA_CONFIG_PATH)
         source_config['source_data_folder'] = source_data_path
-        return SourceData(source_config, self.etl_stats)
+        return SourceData(source_config)
 
     def run(self) -> None:
         print('OMOP wrapper goes brrrrrrrr')

--- a/src/omop_etl_wrapper/wrapper.py
+++ b/src/omop_etl_wrapper/wrapper.py
@@ -141,6 +141,6 @@ class Wrapper(OrmWrapper, RawSqlWrapper):
 
         :return: None
         """
-        etl_stats.log_summary()
         if self._config.run_options.write_reports:
             etl_stats.write_summary_files()
+        etl_stats.log_summary()

--- a/tests/python/model/source_data/test_source_data.py
+++ b/tests/python/model/source_data/test_source_data.py
@@ -1,14 +1,14 @@
 from typing import Dict
 
 import pytest
-from src.omop_etl_wrapper.model.etl_stats import EtlStats
+from src.omop_etl_wrapper.model.etl_stats import etl_stats
 from src.omop_etl_wrapper.model.source_data import SourceData
 
 
 @pytest.fixture
 def source_data1(source_config: Dict) -> SourceData:
     """Return SourceData instance with test_dir1 as source_dir."""
-    return SourceData(source_config, EtlStats())
+    return SourceData(source_config)
 
 
 def test_get_file_returns_the_file(source_data1: SourceData):
@@ -22,9 +22,10 @@ def test_get_non_existing_file_raises_exception(source_data1: SourceData):
 
 
 def test_source_data_counts_are_collected(source_config: Dict):
+    etl_stats.reset()
     source_config['count_source_rows'] = True
-    source_data = SourceData(source_config, EtlStats())
-    assert len(source_data._etl_stats.sources) == 3
+    SourceData(source_config)
+    assert len(etl_stats.sources) == 3
 
 
 def test_source_dir_property(source_data1: SourceData):


### PR DESCRIPTION
Depends on https://github.com/thehyve/ohdsi-etl-template/pull/51
- Get rid of the single EtlStats instance being passed around to many different objects as part of the initialization. Instead there is now a single instance created in the etl_stats module, that is imported in other modules when needed.
- Wrapper now has a single `summarize` method that handles both the logging of the summary report and writing the report files, exact behavior depending on the contents of `MainConfig`.