### PR TITLE
Drop/add all constraints methods

### DIFF
--- a/src/omop_etl_wrapper/cdm/vocabularies/vocabularies.py
+++ b/src/omop_etl_wrapper/cdm/vocabularies/vocabularies.py
@@ -81,11 +81,11 @@ class BaseConceptAncestor:
 
     @declared_attr
     def ancestor_concept_id(cls):
-        return Column(ForeignKey(f'{VOCAB_SCHEMA}.concept.concept_id'), primary_key=True, nullable=False, index=True)
+        return Column(ForeignKey(f'{VOCAB_SCHEMA}.concept.concept_id'), primary_key=True, index=True)
 
     @declared_attr
     def descendant_concept_id(cls):
-        return Column(ForeignKey(f'{VOCAB_SCHEMA}.concept.concept_id'), primary_key=True, nullable=False, index=True)
+        return Column(ForeignKey(f'{VOCAB_SCHEMA}.concept.concept_id'), primary_key=True, index=True)
 
     @declared_attr
     def min_levels_of_separation(cls):
@@ -135,15 +135,15 @@ class BaseConceptRelationship:
 
     @declared_attr
     def concept_id_1(cls):
-        return Column(ForeignKey(f'{VOCAB_SCHEMA}.concept.concept_id'), primary_key=True, nullable=False, index=True)
+        return Column(ForeignKey(f'{VOCAB_SCHEMA}.concept.concept_id'), primary_key=True, index=True)
 
     @declared_attr
     def concept_id_2(cls):
-        return Column(ForeignKey(f'{VOCAB_SCHEMA}.concept.concept_id'), primary_key=True, nullable=False, index=True)
+        return Column(ForeignKey(f'{VOCAB_SCHEMA}.concept.concept_id'), primary_key=True, index=True)
 
     @declared_attr
     def relationship_id(cls):
-        return Column(ForeignKey(f'{VOCAB_SCHEMA}.relationship.relationship_id'), primary_key=True, nullable=False, index=True)
+        return Column(ForeignKey(f'{VOCAB_SCHEMA}.relationship.relationship_id'), primary_key=True, index=True)
 
     @declared_attr
     def valid_start_date(cls):
@@ -182,15 +182,15 @@ class BaseConceptSynonym:
 
     @declared_attr
     def concept_id(cls):
-        return Column(ForeignKey(f'{VOCAB_SCHEMA}.concept.concept_id'), primary_key=True, nullable=False, index=True)
+        return Column(ForeignKey(f'{VOCAB_SCHEMA}.concept.concept_id'), primary_key=True, index=True)
 
     @declared_attr
     def concept_synonym_name(cls):
-        return Column(String(1000), primary_key=True, nullable=False)
+        return Column(String(1000), primary_key=True)
 
     @declared_attr
     def language_concept_id(cls):
-        return Column(ForeignKey(f'{VOCAB_SCHEMA}.concept.concept_id'), primary_key=True, nullable=False)
+        return Column(ForeignKey(f'{VOCAB_SCHEMA}.concept.concept_id'), primary_key=True)
 
     @declared_attr
     def concept(cls):
@@ -228,11 +228,11 @@ class BaseDrugStrength:
 
     @declared_attr
     def drug_concept_id(cls):
-        return Column(ForeignKey(f'{VOCAB_SCHEMA}.concept.concept_id'), primary_key=True, nullable=False, index=True)
+        return Column(ForeignKey(f'{VOCAB_SCHEMA}.concept.concept_id'), primary_key=True, index=True)
 
     @declared_attr
     def ingredient_concept_id(cls):
-        return Column(ForeignKey(f'{VOCAB_SCHEMA}.concept.concept_id'), primary_key=True, nullable=False, index=True)
+        return Column(ForeignKey(f'{VOCAB_SCHEMA}.concept.concept_id'), primary_key=True, index=True)
 
     @declared_attr
     def amount_value(cls):
@@ -338,7 +338,7 @@ class BaseSourceToConceptMap:
 
     @declared_attr
     def source_code(cls):
-        return Column(Text, primary_key=True, nullable=False, index=True)
+        return Column(Text, primary_key=True, index=True)
 
     @declared_attr
     def source_concept_id(cls):
@@ -346,7 +346,7 @@ class BaseSourceToConceptMap:
 
     @declared_attr
     def source_vocabulary_id(cls):
-        return Column(ForeignKey(f'{VOCAB_SCHEMA}.vocabulary.vocabulary_id'), primary_key=True, nullable=False, index=True)
+        return Column(ForeignKey(f'{VOCAB_SCHEMA}.vocabulary.vocabulary_id'), primary_key=True, index=True)
 
     @declared_attr
     def source_code_description(cls):
@@ -354,7 +354,7 @@ class BaseSourceToConceptMap:
 
     @declared_attr
     def target_concept_id(cls):
-        return Column(ForeignKey(f'{VOCAB_SCHEMA}.concept.concept_id'), primary_key=True, nullable=False, index=True)
+        return Column(ForeignKey(f'{VOCAB_SCHEMA}.concept.concept_id'), primary_key=True, index=True)
 
     @declared_attr
     def target_vocabulary_id(cls):
@@ -366,7 +366,7 @@ class BaseSourceToConceptMap:
 
     @declared_attr
     def valid_end_date(cls):
-        return Column(Date, primary_key=True, nullable=False)
+        return Column(Date, primary_key=True)
 
     @declared_attr
     def invalid_reason(cls):

--- a/src/omop_etl_wrapper/cdm/vocabularies/vocabularies.py
+++ b/src/omop_etl_wrapper/cdm/vocabularies/vocabularies.py
@@ -11,14 +11,12 @@ from .._schema_placeholders import VOCAB_SCHEMA
 class BaseConcept:
     __tablename__ = 'concept'
     __table_args__ = (
-        CheckConstraint("(COALESCE(invalid_reason, 'D'::character varying))::text "
-                        "= ANY ((ARRAY['D'::character varying, "
-                        "'U'::character varying])::text[])", name="chk_c_invalid_reason"),
-        CheckConstraint("(COALESCE(standard_concept, 'C'::character varying))::text "
-                        "= ANY ((ARRAY['C'::character varying, "
-                        "'S'::character varying])::text[])", name="chk_c_standard_concept"),
-        CheckConstraint("(concept_code)::text <> ''::text", name="chk_c_concept_code"),
-        CheckConstraint("(concept_name)::text <> ''::text", name="chk_c_concept_name"),
+        CheckConstraint("(COALESCE(invalid_reason,'D') in ('D','U'))",
+                        name="chk_c_invalid_reason"),
+        CheckConstraint("(COALESCE(standard_concept,'C') in ('C','S'))",
+                        name="chk_c_standard_concept"),
+        CheckConstraint("(concept_code <> '')", name="chk_c_concept_code"),
+        CheckConstraint("(concept_name <> '')", name="chk_c_concept_name"),
         {'schema': VOCAB_SCHEMA},
     )
 
@@ -128,8 +126,7 @@ class BaseConceptClass:
 class BaseConceptRelationship:
     __tablename__ = 'concept_relationship'
     __table_args__ = (
-        CheckConstraint("(COALESCE(invalid_reason, 'D'::character varying))::text "
-                        "= 'D'::text", name="chk_cr_invalid_reason"),
+        CheckConstraint("(COALESCE(invalid_reason,'D')='D')", name="chk_cr_invalid_reason"),
         {'schema': VOCAB_SCHEMA},
     )
 
@@ -175,8 +172,7 @@ class BaseConceptSynonym:
     __table_args__ = (
         # UniqueConstraint uq_concept_synonym is not added, because
         # there is already a PK on the same columns
-        CheckConstraint("(concept_synonym_name)::text <> ''::text",
-                        name="chk_csyn_concept_synonym_name"),
+        CheckConstraint("(concept_synonym_name <> '')", name="chk_csyn_concept_synonym_name"),
         {'schema': VOCAB_SCHEMA},
     )
 

--- a/src/omop_etl_wrapper/database/constraints/constraint_manager.py
+++ b/src/omop_etl_wrapper/database/constraints/constraint_manager.py
@@ -463,6 +463,6 @@ class ConstraintManager:
             return False
         if not c1.table.name == c2.table.name:
             return False
-        if not [c.name for c in c1.columns] == [c.name for c in c2.columns]:
+        if not {c.name for c in c1.columns} == {c.name for c in c2.columns}:
             return False
         return True

--- a/src/omop_etl_wrapper/database/constraints/constraint_manager.py
+++ b/src/omop_etl_wrapper/database/constraints/constraint_manager.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import logging
 from copy import copy
 from functools import lru_cache, wraps
-from typing import TYPE_CHECKING, Union, Dict, Callable
+from typing import TYPE_CHECKING, Union, Dict, Callable, List, Tuple
 
 from itertools import chain
 from sqlalchemy import Index, Table, PrimaryKeyConstraint, Constraint, MetaData
@@ -74,8 +74,8 @@ class ConstraintManager:
     """
     Manager for adding and removing table constraints/indexes.
 
-    They can be dropped/added individually, per table, or for all
-    non-vocabulary tables.
+    They can be dropped/added individually, per table, for all
+    non-vocabulary tables, or for all tables.
 
     Dropping does not cascade; meaning that if a constraint cannot be
     dropped because another object depends on it, it will remain active.
@@ -100,6 +100,74 @@ class ConstraintManager:
         ConstraintManager._reflected_table_lookup.fget.cache_clear()
         ConstraintManager._reflected_constraint_lookup.fget.cache_clear()
 
+    def drop_all_constraints(self,
+                             drop_constraint: bool = True,
+                             drop_pk: bool = True,
+                             drop_index: bool = True
+                             ) -> None:
+        """
+        Remove constraints/indexes of all tables (including vocabulary).
+
+        Any table bound to your SQLAlchemy Base will be affected. If
+        there are any additional tables in your database that are not
+        bound to Base, they will not be affected by this method.
+
+        :param drop_constraint: bool, default True
+            If True, drop any FK, unique and check constraints.
+        :param drop_pk: bool, default True
+            If True, drop all PKs.
+        :param drop_index: bool, default True
+            If True, drop all indexes.
+        :return: None
+        """
+        logger.info('Dropping all constraints')
+
+        tables = [table for table in self._db.reflected_metadata.tables.values()
+                  if self._model.is_model_table(table.name)]
+
+        constraints, pks, indexes = self._get_table_objects(tables, drop_constraint,
+                                                            drop_pk, drop_index)
+
+        for constraint in chain(indexes, constraints, pks):
+            self._drop_constraint_in_db(constraint)
+
+    @_invalidate_db_cache
+    def add_all_constraints(self,
+                            add_constraint: bool = True,
+                            add_pk: bool = True,
+                            add_index: bool = True
+                            ) -> None:
+        """
+        Add constraints/indexes of all tables (including vocabulary).
+
+        Any table bound to your SQLAlchemy Base will be affected. If
+        there are any additional tables in your database that are not
+        bound to Base, they will not be affected by this method.
+
+        If some constraints are already present before this method is
+        called, they will remain active and not be added a second time,
+        regardless of constraint names.
+
+        :param add_constraint: bool, default True
+            If True, add all FK, unique and check constraints.
+        :param add_pk: bool, default True
+            If True, add all PKs.
+        :param add_index: bool, default True
+            If True, add all indexes.
+        :return: None
+        """
+        logger.info('Adding all constraints')
+        constraints, pks, indexes = [], [], []
+        if add_index:
+            indexes = self._model.indexes
+        if add_pk:
+            pks = self._model.pks
+        if add_constraint:
+            constraints = self._model.constraints
+
+        for constraint in chain(indexes, pks, constraints):
+            self._add_constraint_in_db(constraint)
+
     def drop_cdm_constraints(self,
                              drop_constraint: bool = True,
                              drop_pk: bool = True,
@@ -122,25 +190,13 @@ class ConstraintManager:
         :return: None
         """
         logger.info('Dropping CDM constraints')
-        # Because we don't know in which order the table constraints can
-        # be dropped without violating one in the process, we first
-        # collect all of them, then drop them in the following order:
-        # indexes, non-pk constraints, pks.
-        constraints, pks, indexes = [], [], []
-        for table in self._db.reflected_metadata.tables.values():
-            if table.name in VOCAB_TABLES or not self._model.is_model_table(table.name):
-                continue
 
-            for constraint in table.constraints:
-                is_pk = isinstance(constraint, PrimaryKeyConstraint)
-                if is_pk and drop_pk:
-                    pks.append(constraint)
-                elif not is_pk and drop_constraint:
-                    constraints.append(constraint)
+        tables = [table for table in self._db.reflected_metadata.tables.values()
+                  if self._model.is_model_table(table.name)
+                  and table.name not in VOCAB_TABLES]
 
-            if drop_index:
-                for index in table.indexes:
-                    indexes.append(index)
+        constraints, pks, indexes = self._get_table_objects(tables, drop_constraint,
+                                                            drop_pk, drop_index)
 
         for constraint in chain(indexes, constraints, pks):
             self._drop_constraint_in_db(constraint)
@@ -319,6 +375,32 @@ class ConstraintManager:
         :return: None
         """
         self._add_constraint_or_index(index)
+
+    @staticmethod
+    def _get_table_objects(tables: List[Table],
+                           drop_constraint: bool,
+                           drop_pk: bool,
+                           drop_index: bool
+                           ) -> Tuple[List[Constraint], List[PrimaryKeyConstraint], List[Index]]:
+        # Return the non-pk constraints, pks and indexes of a list of
+        # tables.
+        # Because we don't know in which order the table constraints can
+        # be dropped without violating one in the process, we first
+        # collect all of them. They can then safely be dropped in the
+        # following order: indexes, non-pk constraints, pks.
+        constraints, pks, indexes = [], [], []
+        for table in tables:
+            for constraint in table.constraints:
+                is_pk = isinstance(constraint, PrimaryKeyConstraint)
+                if is_pk and drop_pk:
+                    pks.append(constraint)
+                elif not is_pk and drop_constraint:
+                    constraints.append(constraint)
+
+            if drop_index:
+                for index in table.indexes:
+                    indexes.append(index)
+        return constraints, pks, indexes
 
     def _add_constraint_or_index(self, constraint_name: str) -> None:
         constraint = self._model.constraint_lookup.get(constraint_name)

--- a/tests/python/database/constraints/constraint_sets.py
+++ b/tests/python/database/constraints/constraint_sets.py
@@ -314,6 +314,12 @@ db_table_objects_full = {
     'pk_visit_detail',
     'pk_visit_occurrence',
     'pk_vocabulary',
+    'ck_concept_chk_c_concept_code',
+    'ck_concept_chk_c_concept_name',
+    'ck_concept_chk_c_invalid_reason',
+    'ck_concept_chk_c_standard_concept',
+    'ck_concept_relationship_chk_cr_invalid_reason',
+    'ck_concept_synonym_chk_csyn_concept_synonym_name',
 }
 
 vocab_table_objects = {
@@ -366,4 +372,10 @@ vocab_table_objects = {
     'pk_relationship',
     'pk_source_to_concept_map',
     'pk_vocabulary',
+    'ck_concept_chk_c_concept_code',
+    'ck_concept_chk_c_concept_name',
+    'ck_concept_chk_c_invalid_reason',
+    'ck_concept_chk_c_standard_concept',
+    'ck_concept_relationship_chk_cr_invalid_reason',
+    'ck_concept_synonym_chk_csyn_concept_synonym_name',
 }

--- a/tests/python/database/constraints/test_constraints.py
+++ b/tests/python/database/constraints/test_constraints.py
@@ -165,3 +165,22 @@ def test_drop_and_add_cdm_constraints(cdm600_wrapper_with_tables_created: Wrappe
     wrapper.db.constraint_manager.add_cdm_constraints()
     all_db_objects = get_all_db_table_object_names(wrapper.db.reflected_metadata)
     assert all_db_objects == expected_sets.db_table_objects_full
+
+
+@pytest.mark.usefixtures("container", "test_db")
+def test_drop_and_add_all_constraints(cdm600_wrapper_with_tables_created: Wrapper):
+    wrapper = cdm600_wrapper_with_tables_created
+
+    # Initially all constraints/indexes are present
+    all_db_objects = get_all_db_table_object_names(wrapper.db.reflected_metadata)
+    assert all_db_objects == expected_sets.db_table_objects_full
+
+    # Calling drop_cdm_constraints without arguments drops everything
+    wrapper.db.constraint_manager.drop_all_constraints()
+    all_db_objects = get_all_db_table_object_names(wrapper.db.reflected_metadata)
+    assert all_db_objects == {None}
+
+    # Calling add_all_constraints restores all constraints/indexes
+    wrapper.db.constraint_manager.add_all_constraints()
+    all_db_objects = get_all_db_table_object_names(wrapper.db.reflected_metadata)
+    assert all_db_objects == expected_sets.db_table_objects_full

--- a/tests/python/database/constraints/test_constraints.py
+++ b/tests/python/database/constraints/test_constraints.py
@@ -86,12 +86,21 @@ def test_drop_and_add_pk(cdm600_wrapper_with_tables_created: Wrapper):
 
 
 @pytest.mark.usefixtures("container", "test_db")
-def test_drop_index_raises_keyerror_if_missing(cdm600_wrapper_with_tables_created: Wrapper):
+def test_raise_keyerror_if_object_not_found(cdm600_wrapper_with_tables_created: Wrapper):
     wrapper = cdm600_wrapper_with_tables_created
 
+    # Cannot add/drop for non-existing tables
+    with pytest.raises(KeyError):
+        wrapper.db.constraint_manager.add_table_constraints('we_lay_my_love_and_i')
+    with pytest.raises(KeyError):
+        wrapper.db.constraint_manager.drop_table_constraints('beneath_the_weeping_willow')
+
+    # Cannot add index that doesn't exist
+    with pytest.raises(KeyError):
+        wrapper.db.constraint_manager.add_index('but_now_alone_i_lie')
     # Cannot drop index that never existed
     with pytest.raises(KeyError):
-        wrapper.db.constraint_manager.drop_index('index_404')
+        wrapper.db.constraint_manager.drop_index('and_weep_beside_the_tree')
 
     # This index can be dropped
     wrapper.db.constraint_manager.drop_index('ix_measurement_person_id')


### PR DESCRIPTION
Closes #55 
- Add methods to the `ConstraintManager` for adding and dropping all constraints/indexes (including vocabulary tables).
- Add check constraints on vocabulary tables (were added in cdm6.0.0).
- Several small fixes/improvements in `ConstraintManager` logic